### PR TITLE
Add toleration for common master node-role taint to bootstrap jobs

### DIFF
--- a/pkg/helm/controller.go
+++ b/pkg/helm/controller.go
@@ -284,6 +284,10 @@ func job(chart *helmv1.HelmChart) (*batch.Job, *core.ConfigMap, *core.ConfigMap)
 				Effect:   "NoSchedule",
 			},
 			{
+				Key:      "node-role.kubernetes.io/master",
+				Operator: core.TolerationOpExists,
+			},
+			{
 				Key:      "CriticalAddonsOnly",
 				Operator: core.TolerationOpExists,
 			},


### PR DESCRIPTION
During development of the @flowswiss cloud-controller-manager we noticed, that we were unable to install our helm chart via the helm-controller due to a missing toleration of the commonly used `node-role.kubernetes.io/master` taint on master nodes. We set this taint so that non-critical applications are not placed on our control-plane nodes. With this change such a toleration is added to the helm install job when setting the `bootstrap: true` property of the helm chart crd. 