### PR TITLE
Update the klipper-helm image

### DIFF
--- a/pkg/helm/controller.go
+++ b/pkg/helm/controller.go
@@ -37,7 +37,7 @@ import (
 var (
 	commaRE              = regexp.MustCompile(`\\*,`)
 	deletePolicy         = meta.DeletePropagationForeground
-	DefaultJobImage      = "rancher/klipper-helm:v0.7.0-build20220315"
+	DefaultJobImage      = "rancher/klipper-helm:v0.7.1-build20220407"
 	DefaultFailurePolicy = FailurePolicyReinstall
 )
 


### PR DESCRIPTION
Main reason is to support ipv6-only

Issue: https://github.com/k3s-io/k3s/issues/5237

Signed-off-by: Manuel Buil <mbuil@suse.com>