### PR TITLE
Enqueue HelmChart update with delay when HelmChartConfig changes

### DIFF
--- a/pkg/helm/controller.go
+++ b/pkg/helm/controller.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	helmv1 "github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1"
 	helmcontroller "github.com/k3s-io/helm-controller/pkg/generated/controllers/helm.cattle.io/v1"
@@ -224,7 +225,7 @@ func (c *Controller) OnConfChange(key string, conf *helmv1.HelmChartConfig) (*he
 			return conf, err
 		}
 	} else if chart != nil {
-		c.helmController.Enqueue(conf.Namespace, conf.Name)
+		c.helmController.EnqueueAfter(conf.Namespace, conf.Name, time.Second)
 	}
 	return conf, nil
 }


### PR DESCRIPTION
Prevents getting stale data from the HelmChartConfig cache when the update is processed: https://github.com/k3s-io/helm-controller/blob/3b34c77f9506ffb5a122a0f28a397185314b6934/pkg/helm/controller.go#L151

* for https://github.com/k3s-io/k3s/issues/5534
