### PR TITLE
Bump klipper-helm to v0.7.6-build20230223

### DIFF
--- a/pkg/controllers/chart/chart.go
+++ b/pkg/controllers/chart/chart.go
@@ -53,7 +53,7 @@ const (
 var (
 	commaRE              = regexp.MustCompile(`\\*,`)
 	deletePolicy         = metav1.DeletePropagationForeground
-	DefaultJobImage      = "rancher/klipper-helm:v0.7.5-build20230118"
+	DefaultJobImage      = "rancher/klipper-helm:v0.7.6-build20230223"
 	DefaultFailurePolicy = FailurePolicyReinstall
 )
 


### PR DESCRIPTION
* Bump klipper-helm to v0.7.6-build20230223
* Related to https://github.com/rancher/rancher/issues/40651