### PR TITLE
Update container version in helm-controller manifests

### DIFF
--- a/manifests/deploy-cluster-scoped.yaml
+++ b/manifests/deploy-cluster-scoped.yaml
@@ -16,5 +16,5 @@ spec:
     spec:
       containers:
         - name: helm-controller
-          image: rancher/helm-controller:v0.12.1
+          image: rancher/helm-controller:v0.15.0
           command: ["helm-controller"]

--- a/manifests/deploy-namespaced.yaml
+++ b/manifests/deploy-namespaced.yaml
@@ -24,6 +24,6 @@ spec:
     spec:
       containers:
         - name: helm-controller
-          image: rancher/helm-controller:v0.12.1
+          image: rancher/helm-controller:v0.15.0
           command: ["helm-controller"]
           args: ["--namespace", "helm-controller"]


### PR DESCRIPTION
During my tests, I discovered that
- the Go binary in its current version will automatically deploy all needed CRDs 
- so will the v15 version of the containers
- the v12 version did not do that in my tests.

My tests are running on the current Azure AKS. If you need the full versions to track this down, please let me know. 