### PR TITLE
Add support for docker registry secret

### DIFF
--- a/pkg/apis/helm.cattle.io/v1/types.go
+++ b/pkg/apis/helm.cattle.io/v1/types.go
@@ -36,7 +36,8 @@ type HelmChartSpec struct {
 	FailurePolicy   string                        `json:"failurePolicy,omitempty"`
 	AuthSecret      *corev1.LocalObjectReference  `json:"authSecret,omitempty"`
 
-	AuthPassCredentials bool `json:"authPassCredentials,omitempty"`
+	AuthPassCredentials  bool                         `json:"authPassCredentials,omitempty"`
+	DockerRegistrySecret *corev1.LocalObjectReference `json:"dockerRegistrySecret,omitempty"`
 }
 
 type HelmChartStatus struct {

--- a/pkg/apis/helm.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/helm.cattle.io/v1/zz_generated_deepcopy.go
@@ -190,6 +190,11 @@ func (in *HelmChartSpec) DeepCopyInto(out *HelmChartSpec) {
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
+	if in.DockerRegistrySecret != nil {
+		in, out := &in.DockerRegistrySecret, &out.DockerRegistrySecret
+		*out = new(corev1.LocalObjectReference)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
This allows OCI registries to inherit configuration from the configured docker-registry secret

**Linked Issues**
* https://github.com/k3s-io/helm-controller/issues/81