### PR TITLE
support custom backOffLimit

### DIFF
--- a/pkg/apis/helm.cattle.io/v1/types.go
+++ b/pkg/apis/helm.cattle.io/v1/types.go
@@ -32,6 +32,7 @@ type HelmChartSpec struct {
 	Bootstrap       bool                          `json:"bootstrap,omitempty"`
 	ChartContent    string                        `json:"chartContent,omitempty"`
 	JobImage        string                        `json:"jobImage,omitempty"`
+	BackOffLimit    *int32                        `json:"backOffLimit,omitempty"`
 	Timeout         *metav1.Duration              `json:"timeout,omitempty"`
 	FailurePolicy   string                        `json:"failurePolicy,omitempty"`
 	AuthSecret      *corev1.LocalObjectReference  `json:"authSecret,omitempty"`

--- a/pkg/apis/helm.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/helm.cattle.io/v1/zz_generated_deepcopy.go
@@ -180,6 +180,11 @@ func (in *HelmChartSpec) DeepCopyInto(out *HelmChartSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.BackOffLimit != nil {
+		in, out := &in.BackOffLimit, &out.BackOffLimit
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
 		*out = new(metav1.Duration)

--- a/pkg/generated/controllers/helm.cattle.io/v1/interface.go
+++ b/pkg/generated/controllers/helm.cattle.io/v1/interface.go
@@ -21,6 +21,7 @@ package v1
 import (
 	v1 "github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1"
 	"github.com/rancher/lasso/pkg/controller"
+	"github.com/rancher/wrangler/pkg/generic"
 	"github.com/rancher/wrangler/pkg/schemes"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -44,9 +45,14 @@ type version struct {
 	controllerFactory controller.SharedControllerFactory
 }
 
-func (c *version) HelmChart() HelmChartController {
-	return NewHelmChartController(schema.GroupVersionKind{Group: "helm.cattle.io", Version: "v1", Kind: "HelmChart"}, "helmcharts", true, c.controllerFactory)
+func (v *version) HelmChart() HelmChartController {
+	return &HelmChartGenericController{
+		generic.NewController[*v1.HelmChart, *v1.HelmChartList](schema.GroupVersionKind{Group: "helm.cattle.io", Version: "v1", Kind: "HelmChart"}, "helmcharts", true, v.controllerFactory),
+	}
 }
-func (c *version) HelmChartConfig() HelmChartConfigController {
-	return NewHelmChartConfigController(schema.GroupVersionKind{Group: "helm.cattle.io", Version: "v1", Kind: "HelmChartConfig"}, "helmchartconfigs", true, c.controllerFactory)
+
+func (v *version) HelmChartConfig() HelmChartConfigController {
+	return &HelmChartConfigGenericController{
+		generic.NewController[*v1.HelmChartConfig, *v1.HelmChartConfigList](schema.GroupVersionKind{Group: "helm.cattle.io", Version: "v1", Kind: "HelmChartConfig"}, "helmchartconfigs", true, v.controllerFactory),
+	}
 }

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -203,3 +203,10 @@ func (f *Framework) WaitForChartApp(chart *v1.HelmChart, appName string, timeout
 		return len(pods) >= count, nil
 	})
 }
+
+func (f *Framework) GetJob(chart *v1.HelmChart) (*batchv1.Job, error) {
+	if chart.Status.JobName == "" {
+		return nil, fmt.Errorf("waiting for job name to be populated")
+	}
+	return f.ClientSet.BatchV1().Jobs(chart.Namespace).Get(context.TODO(), chart.Status.JobName, metav1.GetOptions{})
+}


### PR DESCRIPTION
PR allows users to define a custom backOffLimit for the helm install/delete jobs via the HelmChartConfig CRD.

The default of 1000 can be too large when we need install/deletes to fail with a more reasonable retry count.