### PR TITLE
Bump default job image to v0.8.2-build20230815

### DIFF
--- a/pkg/controllers/chart/chart.go
+++ b/pkg/controllers/chart/chart.go
@@ -53,7 +53,7 @@ const (
 var (
 	commaRE              = regexp.MustCompile(`\\*,`)
 	deletePolicy         = metav1.DeletePropagationForeground
-	DefaultJobImage      = "rancher/klipper-helm:v0.8.0-build20230510"
+	DefaultJobImage      = "rancher/klipper-helm:v0.8.2-build20230815"
 	DefaultFailurePolicy = FailurePolicyReinstall
 	defaultBackOffLimit  = pointer.Int32(1000)
 )


### PR DESCRIPTION
* https://github.com/k3s-io/klipper-helm/pull/68

> Updates helm to v3.12.3, and plugins to versions that also use helm v3.12.3 and fixed versions of client-go.
>
> Pulls in fix for https://github.com/helm/helm/issues/12061: crash in kubernetes client libraries when older releases of prometheus-adapter's `v1beta1.custom.metrics.k8s.io` APIService is present in the cluster.