### PR TITLE
Parametrize job cluster role and image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
 /.dapper
 /.idea
+/Dockerfile.dapper*
+!/Dockerfile.dapper
 /bin
 /dist
 helm-controller

--- a/.golangci.json
+++ b/.golangci.json
@@ -36,6 +36,10 @@
 			{
 				"linters": "revive",
 				"text": "unused-parameter"
+			},
+			{
+				"path": "_test\\.go$",
+				"text": "dot-imports: should not use dot imports"
 			}
 		]
 	}

--- a/main.go
+++ b/main.go
@@ -26,13 +26,13 @@ var (
 )
 
 type HelmController struct {
-	Kubeconfig     string `short:"k" usage:"Kubernetes config files, e.g. $HOME/.kube/config" env:"KUBECONFIG"`
-	MasterURL      string `short:"m" usage:"Kubernetes cluster master URL" env:"MASTERURL"`
-	Namespace      string `short:"n" usage:"Namespace to watch, empty means it will watch CRDs in all namespaces." env:"NAMESPACE"`
-	Threads        int    `short:"t" usage:"Threadiness level to set, defaults to 2." default:"2" env:"THREADS"`
-	ControllerName string `usage:"Unique name to identify this controller that is added to all HelmCharts tracked by this controller" default:"helm-controller" env:"CONTROLLER_NAME"`
-	NodeName       string `usage:"Name of the node this controller is running on" env:"NODE_NAME"`
-	PprofPort      int    `usage:"Port to publish HTTP server runtime profiling data in the format expected by the pprof visualization tool. Only enabled if in debug mode" default:"6060"`
+	Kubeconfig     string `short:"k" usage:"Kubernetes config files, e.g. $HOME/.kube/config. May be set via KUBECONFIG env var." env:"KUBECONFIG"`
+	MasterURL      string `short:"m" usage:"Kubernetes cluster master URL. May be set via MASTERURL env var." env:"MASTERURL"`
+	Namespace      string `short:"n" usage:"Namespace to watch, empty means it will watch CRDs in all namespaces. May be set via NAMESPACE env var." env:"NAMESPACE"`
+	Threads        int    `short:"t" usage:"Threadiness level to set. May be set via THREADS env var." default:"2" env:"THREADS"`
+	ControllerName string `usage:"Unique name to identify this controller that is added to all HelmCharts tracked by this controller. May be set via CONTROLLER_NAME env var." default:"helm-controller" env:"CONTROLLER_NAME"`
+	NodeName       string `usage:"Name of the node this controller is running on. May be set via NODE_NAME env var." env:"NODE_NAME"`
+	PprofPort      int    `usage:"Port to publish HTTP server runtime profiling data in the format expected by the pprof visualization tool. Only enabled if in debug mode." default:"6060"`
 }
 
 func (a *HelmController) Run(cmd *cobra.Command, args []string) error {

--- a/main.go
+++ b/main.go
@@ -26,14 +26,15 @@ var (
 )
 
 type HelmController struct {
-	Kubeconfig     string `short:"k" usage:"Kubernetes config files, e.g. $HOME/.kube/config. May be set via KUBECONFIG env var." env:"KUBECONFIG"`
-	MasterURL      string `short:"m" usage:"Kubernetes cluster master URL. May be set via MASTERURL env var." env:"MASTERURL"`
-	Namespace      string `short:"n" usage:"Namespace to watch, empty means it will watch CRDs in all namespaces. May be set via NAMESPACE env var." env:"NAMESPACE"`
-	Threads        int    `short:"t" usage:"Threadiness level to set. May be set via THREADS env var." default:"2" env:"THREADS"`
-	ControllerName string `usage:"Unique name to identify this controller that is added to all HelmCharts tracked by this controller. May be set via CONTROLLER_NAME env var." default:"helm-controller" env:"CONTROLLER_NAME"`
-	NodeName       string `usage:"Name of the node this controller is running on. May be set via NODE_NAME env var." env:"NODE_NAME"`
-	JobClusterRole string `usage:"Name of the cluster role to use for jobs created to manage helm charts. May be set via JOB_CLUSTER_ROLE env var." default:"cluster-admin" env:"JOB_CLUSTER_ROLE"`
-	PprofPort      int    `usage:"Port to publish HTTP server runtime profiling data in the format expected by the pprof visualization tool. Only enabled if in debug mode." default:"6060"`
+	Kubeconfig      string `short:"k" usage:"Kubernetes config files, e.g. $HOME/.kube/config. May be set via KUBECONFIG env var." env:"KUBECONFIG"`
+	MasterURL       string `short:"m" usage:"Kubernetes cluster master URL. May be set via MASTERURL env var." env:"MASTERURL"`
+	Namespace       string `short:"n" usage:"Namespace to watch, empty means it will watch CRDs in all namespaces. May be set via NAMESPACE env var." env:"NAMESPACE"`
+	Threads         int    `short:"t" usage:"Threadiness level to set. May be set via THREADS env var." default:"2" env:"THREADS"`
+	ControllerName  string `usage:"Unique name to identify this controller that is added to all HelmCharts tracked by this controller. May be set via CONTROLLER_NAME env var." default:"helm-controller" env:"CONTROLLER_NAME"`
+	NodeName        string `usage:"Name of the node this controller is running on. May be set via NODE_NAME env var." env:"NODE_NAME"`
+	JobClusterRole  string `usage:"Name of the cluster role to use for jobs created to manage helm charts. May be set via JOB_CLUSTER_ROLE env var." default:"cluster-admin" env:"JOB_CLUSTER_ROLE"`
+	DefaultJobImage string `usage:"Default image to use by jobs managing helm charts. May be set via DEFAULT_JOB_IMAGE env var." env:"DEFAULT_JOB_IMAGE"`
+	PprofPort       int    `usage:"Port to publish HTTP server runtime profiling data in the format expected by the pprof visualization tool. Only enabled if in debug mode." default:"6060"`
 }
 
 func (a *HelmController) Run(cmd *cobra.Command, args []string) error {
@@ -61,9 +62,10 @@ func (a *HelmController) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	opts := common.Options{
-		Threadiness:    a.Threads,
-		NodeName:       a.NodeName,
-		JobClusterRole: a.JobClusterRole,
+		Threadiness:     a.Threads,
+		NodeName:        a.NodeName,
+		JobClusterRole:  a.JobClusterRole,
+		DefaultJobImage: a.DefaultJobImage,
 	}
 
 	if err := opts.Validate(); err != nil {

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ type HelmController struct {
 	Threads        int    `short:"t" usage:"Threadiness level to set. May be set via THREADS env var." default:"2" env:"THREADS"`
 	ControllerName string `usage:"Unique name to identify this controller that is added to all HelmCharts tracked by this controller. May be set via CONTROLLER_NAME env var." default:"helm-controller" env:"CONTROLLER_NAME"`
 	NodeName       string `usage:"Name of the node this controller is running on. May be set via NODE_NAME env var." env:"NODE_NAME"`
+	JobClusterRole string `usage:"Name of the cluster role to use for jobs created to manage helm charts. May be set via JOB_CLUSTER_ROLE env var." default:"cluster-admin" env:"JOB_CLUSTER_ROLE"`
 	PprofPort      int    `usage:"Port to publish HTTP server runtime profiling data in the format expected by the pprof visualization tool. Only enabled if in debug mode." default:"6060"`
 }
 
@@ -60,8 +61,9 @@ func (a *HelmController) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	opts := common.Options{
-		Threadiness: a.Threads,
-		NodeName:    a.NodeName,
+		Threadiness:    a.Threads,
+		NodeName:       a.NodeName,
+		JobClusterRole: a.JobClusterRole,
 	}
 
 	if err := opts.Validate(); err != nil {

--- a/pkg/controllers/chart/chart_test.go
+++ b/pkg/controllers/chart/chart_test.go
@@ -53,6 +53,14 @@ func TestDeleteJob(t *testing.T) {
 	assert.Equal("helm-delete-traefik", job.Name)
 }
 
+func TestInstallJobImage(t *testing.T) {
+	assert := assert.New(t)
+	chart := NewChart()
+	chart.Spec.JobImage = "custom-job-image"
+	job, _, _ := job(chart, "6443")
+	assert.Equal("custom-job-image", job.Spec.Template.Spec.Containers[0].Image)
+}
+
 func TestInstallArgs(t *testing.T) {
 	assert := assert.New(t)
 	stringArgs := strings.Join(args(NewChart()), " ")

--- a/pkg/controllers/common/options.go
+++ b/pkg/controllers/common/options.go
@@ -4,8 +4,9 @@ import "fmt"
 
 // Options defines options that can be set on initializing the Helm Controller
 type Options struct {
-	Threadiness int
-	NodeName    string
+	Threadiness    int
+	NodeName       string
+	JobClusterRole string
 }
 
 func (opts Options) Validate() error {

--- a/pkg/controllers/common/options.go
+++ b/pkg/controllers/common/options.go
@@ -4,9 +4,10 @@ import "fmt"
 
 // Options defines options that can be set on initializing the Helm Controller
 type Options struct {
-	Threadiness    int
-	NodeName       string
-	JobClusterRole string
+	Threadiness     int
+	NodeName        string
+	JobClusterRole  string
+	DefaultJobImage string
 }
 
 func (opts Options) Validate() error {

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -75,6 +75,7 @@ func Register(ctx context.Context, systemNamespace, controllerName string, cfg c
 	chart.Register(ctx,
 		systemNamespace,
 		controllerName,
+		opts.JobClusterRole,
 		"6443",
 		appCtx.K8s,
 		appCtx.Apply,
@@ -91,6 +92,7 @@ func Register(ctx context.Context, systemNamespace, controllerName string, cfg c
 		appCtx.Core.Secret())
 
 	klog.Infof("Starting helm controller with %d threads", opts.Threadiness)
+	klog.Infof("Using cluster role '%s' for jobs managing helm charts", opts.JobClusterRole)
 
 	if len(systemNamespace) == 0 {
 		klog.Info("Starting helm controller with no namespace")

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -72,6 +72,11 @@ func Register(ctx context.Context, systemNamespace, controllerName string, cfg c
 		controllerName = "helm-controller"
 	}
 
+	// apply custom DefaultJobImage option to Helm before starting charts controller
+	if opts.DefaultJobImage != "" {
+		chart.DefaultJobImage = opts.DefaultJobImage
+	}
+
 	chart.Register(ctx,
 		systemNamespace,
 		controllerName,
@@ -93,6 +98,7 @@ func Register(ctx context.Context, systemNamespace, controllerName string, cfg c
 
 	klog.Infof("Starting helm controller with %d threads", opts.Threadiness)
 	klog.Infof("Using cluster role '%s' for jobs managing helm charts", opts.JobClusterRole)
+	klog.Infof("Using default image '%s' for jobs managing helm charts", chart.DefaultJobImage)
 
 	if len(systemNamespace) == 0 {
 		klog.Info("Starting helm controller with no namespace")

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -7,6 +7,11 @@ K3S_VERSION=v1.25.9-k3s1
 
 cd $(dirname $0)/..
 
+if [[ ! -f 'bin/helm-controller-image.txt' ]]; then
+    echo "Run 'make package' first."
+    exit 1
+fi
+
 setup_k8s(){
     # Using k3s with embedded helm controller disabled
     docker pull rancher/k3s:$K3S_VERSION

--- a/scripts/package
+++ b/scripts/package
@@ -8,6 +8,11 @@ SUFFIX="-${ARCH}"
 
 cd $(dirname $0)/..
 
+if [[ ! -f 'bin/helm-controller' ]]; then
+    echo "Run 'make build' first."
+    exit 1
+fi
+
 TAG=${TAG:-${VERSION}${SUFFIX}}
 REPO=${REPO:-rancher}
 


### PR DESCRIPTION
Mainly implements #213 and additionally allows also specyfiying Cluster Role to be used with job images. These are changes that are needed in a hermetic, corporate environment with no direct access to the Internet and a zero-trust policy. I also made other improvements that I felt were appropriate, as a fresh person joining the project.

Constructive comments welcome — I'm a Golang newbie, albeit with a non-short programming experience.