### PR TITLE
Adding securityContext

### DIFF
--- a/pkg/apis/helm.cattle.io/v1/types.go
+++ b/pkg/apis/helm.cattle.io/v1/types.go
@@ -19,28 +19,29 @@ type HelmChart struct {
 }
 
 type HelmChartSpec struct {
-	TargetNamespace    string                        `json:"targetNamespace,omitempty"`
-	CreateNamespace    bool                          `json:"createNamespace,omitempty"`
-	Chart              string                        `json:"chart,omitempty"`
-	Version            string                        `json:"version,omitempty"`
-	Repo               string                        `json:"repo,omitempty"`
-	RepoCA             string                        `json:"repoCA,omitempty"`
-	RepoCAConfigMap    *corev1.LocalObjectReference  `json:"repoCAConfigMap,omitempty"`
-	Set                map[string]intstr.IntOrString `json:"set,omitempty"`
-	ValuesContent      string                        `json:"valuesContent,omitempty"`
-	HelmVersion        string                        `json:"helmVersion,omitempty"`
-	Bootstrap          bool                          `json:"bootstrap,omitempty"`
-	ChartContent       string                        `json:"chartContent,omitempty"`
-	JobImage           string                        `json:"jobImage,omitempty"`
-	BackOffLimit       *int32                        `json:"backOffLimit,omitempty"`
-	Timeout            *metav1.Duration              `json:"timeout,omitempty"`
-	FailurePolicy      string                        `json:"failurePolicy,omitempty"`
-	AuthSecret         *corev1.LocalObjectReference  `json:"authSecret,omitempty"`
-	PodSecurityContext *corev1.PodSecurityContext    `json:"podSecurityContext,omitempty"`
-	SecurityContext    *corev1.SecurityContext       `json:"securityContext,omitempty"`
+	TargetNamespace string                        `json:"targetNamespace,omitempty"`
+	CreateNamespace bool                          `json:"createNamespace,omitempty"`
+	Chart           string                        `json:"chart,omitempty"`
+	Version         string                        `json:"version,omitempty"`
+	Repo            string                        `json:"repo,omitempty"`
+	RepoCA          string                        `json:"repoCA,omitempty"`
+	RepoCAConfigMap *corev1.LocalObjectReference  `json:"repoCAConfigMap,omitempty"`
+	Set             map[string]intstr.IntOrString `json:"set,omitempty"`
+	ValuesContent   string                        `json:"valuesContent,omitempty"`
+	HelmVersion     string                        `json:"helmVersion,omitempty"`
+	Bootstrap       bool                          `json:"bootstrap,omitempty"`
+	ChartContent    string                        `json:"chartContent,omitempty"`
+	JobImage        string                        `json:"jobImage,omitempty"`
+	BackOffLimit    *int32                        `json:"backOffLimit,omitempty"`
+	Timeout         *metav1.Duration              `json:"timeout,omitempty"`
+	FailurePolicy   string                        `json:"failurePolicy,omitempty"`
+	AuthSecret      *corev1.LocalObjectReference  `json:"authSecret,omitempty"`
 
 	AuthPassCredentials  bool                         `json:"authPassCredentials,omitempty"`
 	DockerRegistrySecret *corev1.LocalObjectReference `json:"dockerRegistrySecret,omitempty"`
+
+	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
+	SecurityContext    *corev1.SecurityContext    `json:"securityContext,omitempty"`
 }
 
 type HelmChartStatus struct {

--- a/pkg/apis/helm.cattle.io/v1/types.go
+++ b/pkg/apis/helm.cattle.io/v1/types.go
@@ -19,23 +19,25 @@ type HelmChart struct {
 }
 
 type HelmChartSpec struct {
-	TargetNamespace string                        `json:"targetNamespace,omitempty"`
-	CreateNamespace bool                          `json:"createNamespace,omitempty"`
-	Chart           string                        `json:"chart,omitempty"`
-	Version         string                        `json:"version,omitempty"`
-	Repo            string                        `json:"repo,omitempty"`
-	RepoCA          string                        `json:"repoCA,omitempty"`
-	RepoCAConfigMap *corev1.LocalObjectReference  `json:"repoCAConfigMap,omitempty"`
-	Set             map[string]intstr.IntOrString `json:"set,omitempty"`
-	ValuesContent   string                        `json:"valuesContent,omitempty"`
-	HelmVersion     string                        `json:"helmVersion,omitempty"`
-	Bootstrap       bool                          `json:"bootstrap,omitempty"`
-	ChartContent    string                        `json:"chartContent,omitempty"`
-	JobImage        string                        `json:"jobImage,omitempty"`
-	BackOffLimit    *int32                        `json:"backOffLimit,omitempty"`
-	Timeout         *metav1.Duration              `json:"timeout,omitempty"`
-	FailurePolicy   string                        `json:"failurePolicy,omitempty"`
-	AuthSecret      *corev1.LocalObjectReference  `json:"authSecret,omitempty"`
+	TargetNamespace    string                        `json:"targetNamespace,omitempty"`
+	CreateNamespace    bool                          `json:"createNamespace,omitempty"`
+	Chart              string                        `json:"chart,omitempty"`
+	Version            string                        `json:"version,omitempty"`
+	Repo               string                        `json:"repo,omitempty"`
+	RepoCA             string                        `json:"repoCA,omitempty"`
+	RepoCAConfigMap    *corev1.LocalObjectReference  `json:"repoCAConfigMap,omitempty"`
+	Set                map[string]intstr.IntOrString `json:"set,omitempty"`
+	ValuesContent      string                        `json:"valuesContent,omitempty"`
+	HelmVersion        string                        `json:"helmVersion,omitempty"`
+	Bootstrap          bool                          `json:"bootstrap,omitempty"`
+	ChartContent       string                        `json:"chartContent,omitempty"`
+	JobImage           string                        `json:"jobImage,omitempty"`
+	BackOffLimit       *int32                        `json:"backOffLimit,omitempty"`
+	Timeout            *metav1.Duration              `json:"timeout,omitempty"`
+	FailurePolicy      string                        `json:"failurePolicy,omitempty"`
+	AuthSecret         *corev1.LocalObjectReference  `json:"authSecret,omitempty"`
+	PodSecurityContext *corev1.PodSecurityContext    `json:"podSecurityContext,omitempty"`
+	SecurityContext    *corev1.SecurityContext       `json:"securityContext,omitempty"`
 
 	AuthPassCredentials  bool                         `json:"authPassCredentials,omitempty"`
 	DockerRegistrySecret *corev1.LocalObjectReference `json:"dockerRegistrySecret,omitempty"`

--- a/pkg/controllers/chart/chart.go
+++ b/pkg/controllers/chart/chart.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
-	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -895,37 +894,12 @@ func setBackOffLimit(job *batch.Job, backOffLimit *int32) {
 	job.Spec.BackoffLimit = backOffLimit
 }
 
-func deepMergeStruct(target, source interface{}) {
-	targetVal := reflect.ValueOf(target).Elem()
-	sourceVal := reflect.ValueOf(source).Elem()
-
-	for i := 0; i < targetVal.NumField(); i++ {
-		targetField := targetVal.Field(i)
-		sourceField := sourceVal.Field(i)
-
-		if !sourceField.IsNil() {
-			if targetField.IsNil() {
-				targetField.Set(sourceField)
-			} else {
-				// If fields are pointers and Structs, merge recursively
-				if targetField.Kind() == reflect.Ptr && targetField.Elem().Kind() == reflect.Struct &&
-					sourceField.Kind() == reflect.Ptr && sourceField.Elem().Kind() == reflect.Struct {
-					deepMergeStruct(targetField.Interface(), sourceField.Interface())
-				} else {
-					// Otherwise, overwrite target field with source field value
-					targetField.Set(sourceField)
-				}
-			}
-		}
-	}
-}
-
 func setSecurityContext(job *batch.Job, chart *v1.HelmChart) {
 	if chart.Spec.PodSecurityContext != nil {
-		deepMergeStruct(job.Spec.Template.Spec.SecurityContext, chart.Spec.PodSecurityContext)
+		job.Spec.Template.Spec.SecurityContext = chart.Spec.PodSecurityContext
 	}
 
 	if chart.Spec.SecurityContext != nil {
-		deepMergeStruct(job.Spec.Template.Spec.Containers[0].SecurityContext, chart.Spec.SecurityContext)
+		job.Spec.Template.Spec.Containers[0].SecurityContext = chart.Spec.SecurityContext
 	}
 }

--- a/test/suite/helm_test.go
+++ b/test/suite/helm_test.go
@@ -536,9 +536,6 @@ var _ = Describe("Helm Tests", Ordered, func() {
 			job                        *batchv1.Job
 			expectedPodSecurityContext = &corev1.PodSecurityContext{
 				RunAsNonRoot: pointer.BoolPtr(false),
-				SeccompProfile: &corev1.SeccompProfile{
-					Type: "RuntimeDefault",
-				},
 			}
 		)
 		BeforeEach(func() {
@@ -651,12 +648,6 @@ var _ = Describe("Helm Tests", Ordered, func() {
 			job                     *batchv1.Job
 			expectedSecurityContext = &corev1.SecurityContext{
 				AllowPrivilegeEscalation: pointer.BoolPtr(true),
-				Capabilities: &corev1.Capabilities{
-					Drop: []corev1.Capability{
-						"ALL",
-					},
-				},
-				ReadOnlyRootFilesystem: pointer.BoolPtr(true),
 			}
 		)
 		BeforeEach(func() {

--- a/test/suite/helm_test.go
+++ b/test/suite/helm_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("Helm Tests", Ordered, func() {
@@ -362,7 +363,6 @@ var _ = Describe("Helm Tests", Ordered, func() {
 				_, err := framework.GetHelmChart(chart.Name, framework.Namespace)
 				return err != nil && apierrors.IsNotFound(err)
 			}, 120*time.Second, 5*time.Second).Should(BeTrue())
-
 		})
 	})
 
@@ -474,7 +474,6 @@ var _ = Describe("Helm Tests", Ordered, func() {
 				return err != nil && apierrors.IsNotFound(err)
 			}, 120*time.Second, 5*time.Second).Should(BeTrue())
 		})
-
 	})
 
 	Context("When a no backoffLimit is specified", func() {
@@ -528,6 +527,241 @@ var _ = Describe("Helm Tests", Ordered, func() {
 				return err != nil && apierrors.IsNotFound(err)
 			}, 120*time.Second, 5*time.Second).Should(BeTrue())
 		})
+	})
 
+	Context("When a custom podSecurityContext is specified", func() {
+		var (
+			err                        error
+			chart                      *v1.HelmChart
+			job                        *batchv1.Job
+			expectedPodSecurityContext = &corev1.PodSecurityContext{
+				RunAsNonRoot: pointer.BoolPtr(false),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: "RuntimeDefault",
+				},
+			}
+		)
+		BeforeEach(func() {
+			chart = framework.NewHelmChart("traefik-example-custom-podsecuritycontext",
+				"stable/traefik",
+				"1.86.1",
+				"v3",
+				map[string]intstr.IntOrString{
+					"rbac.enabled": {
+						Type:   intstr.String,
+						StrVal: "true",
+					},
+					"ssl.enabled": {
+						Type:   intstr.String,
+						StrVal: "true",
+					},
+				})
+			chart.Spec.PodSecurityContext = &corev1.PodSecurityContext{
+				RunAsNonRoot: pointer.BoolPtr(false),
+			}
+			chart, err = framework.CreateHelmChart(chart, framework.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			labelSelector := labels.SelectorFromSet(labels.Set{
+				"owner": "helm",
+				"name":  chart.Name,
+			})
+			_, err = framework.WaitForRelease(chart, labelSelector, 120*time.Second, 1)
+			Expect(err).ToNot(HaveOccurred())
+
+			chart, err = framework.GetHelmChart(chart.Name, chart.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+			job, err = framework.GetJob(chart)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("Should have correct pod securityContext", func() {
+			Expect(*job.Spec.Template.Spec.SecurityContext).To(Equal(*expectedPodSecurityContext))
+		})
+		AfterEach(func() {
+			err = framework.DeleteHelmChart(chart.Name, framework.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				_, err := framework.GetHelmChart(chart.Name, framework.Namespace)
+				return err != nil && apierrors.IsNotFound(err)
+			}, 120*time.Second, 5*time.Second).Should(BeTrue())
+		})
+	})
+
+	Context("When a no podSecurityContext is specified", func() {
+		var (
+			err                       error
+			chart                     *v1.HelmChart
+			job                       *batchv1.Job
+			defaultPodSecurityContext = &corev1.PodSecurityContext{
+				RunAsNonRoot: pointer.BoolPtr(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: "RuntimeDefault",
+				},
+			}
+		)
+		BeforeEach(func() {
+			chart = framework.NewHelmChart("traefik-example-default-podsecuritycontext",
+				"stable/traefik",
+				"1.86.1",
+				"v3",
+				map[string]intstr.IntOrString{
+					"rbac.enabled": {
+						Type:   intstr.String,
+						StrVal: "true",
+					},
+					"ssl.enabled": {
+						Type:   intstr.String,
+						StrVal: "true",
+					},
+				})
+			chart, err = framework.CreateHelmChart(chart, framework.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			labelSelector := labels.SelectorFromSet(labels.Set{
+				"owner": "helm",
+				"name":  chart.Name,
+			})
+			_, err = framework.WaitForRelease(chart, labelSelector, 120*time.Second, 1)
+			Expect(err).ToNot(HaveOccurred())
+
+			chart, err = framework.GetHelmChart(chart.Name, chart.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+			job, err = framework.GetJob(chart)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("Should have correct pod securityContext", func() {
+			Expect(*job.Spec.Template.Spec.SecurityContext).To(Equal(*defaultPodSecurityContext))
+		})
+		AfterEach(func() {
+			err = framework.DeleteHelmChart(chart.Name, framework.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				_, err := framework.GetHelmChart(chart.Name, framework.Namespace)
+				return err != nil && apierrors.IsNotFound(err)
+			}, 120*time.Second, 5*time.Second).Should(BeTrue())
+		})
+	})
+
+	Context("When a custom securityContext is specified", func() {
+		var (
+			err                     error
+			chart                   *v1.HelmChart
+			job                     *batchv1.Job
+			expectedSecurityContext = &corev1.SecurityContext{
+				AllowPrivilegeEscalation: pointer.BoolPtr(true),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{
+						"ALL",
+					},
+				},
+				ReadOnlyRootFilesystem: pointer.BoolPtr(true),
+			}
+		)
+		BeforeEach(func() {
+			chart = framework.NewHelmChart("traefik-example-custom-securitycontext",
+				"stable/traefik",
+				"1.86.1",
+				"v3",
+				map[string]intstr.IntOrString{
+					"rbac.enabled": {
+						Type:   intstr.String,
+						StrVal: "true",
+					},
+					"ssl.enabled": {
+						Type:   intstr.String,
+						StrVal: "true",
+					},
+				})
+			chart.Spec.SecurityContext = &corev1.SecurityContext{
+				AllowPrivilegeEscalation: pointer.BoolPtr(true),
+			}
+			chart, err = framework.CreateHelmChart(chart, framework.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			labelSelector := labels.SelectorFromSet(labels.Set{
+				"owner": "helm",
+				"name":  chart.Name,
+			})
+			_, err = framework.WaitForRelease(chart, labelSelector, 120*time.Second, 1)
+			Expect(err).ToNot(HaveOccurred())
+
+			chart, err = framework.GetHelmChart(chart.Name, chart.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+			job, err = framework.GetJob(chart)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("Should have correct container securityContext", func() {
+			Expect(*job.Spec.Template.Spec.Containers[0].SecurityContext).To(Equal(*expectedSecurityContext))
+		})
+		AfterEach(func() {
+			err = framework.DeleteHelmChart(chart.Name, framework.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				_, err := framework.GetHelmChart(chart.Name, framework.Namespace)
+				return err != nil && apierrors.IsNotFound(err)
+			}, 120*time.Second, 5*time.Second).Should(BeTrue())
+		})
+	})
+
+	Context("When a no securityContext is specified", func() {
+		var (
+			err                    error
+			chart                  *v1.HelmChart
+			job                    *batchv1.Job
+			defaultSecurityContext = &corev1.SecurityContext{
+				AllowPrivilegeEscalation: pointer.BoolPtr(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{
+						"ALL",
+					},
+				},
+				ReadOnlyRootFilesystem: pointer.BoolPtr(true),
+			}
+		)
+		BeforeEach(func() {
+			chart = framework.NewHelmChart("traefik-example-default-securitycontext",
+				"stable/traefik",
+				"1.86.1",
+				"v3",
+				map[string]intstr.IntOrString{
+					"rbac.enabled": {
+						Type:   intstr.String,
+						StrVal: "true",
+					},
+					"ssl.enabled": {
+						Type:   intstr.String,
+						StrVal: "true",
+					},
+				})
+			chart, err = framework.CreateHelmChart(chart, framework.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			labelSelector := labels.SelectorFromSet(labels.Set{
+				"owner": "helm",
+				"name":  chart.Name,
+			})
+			_, err = framework.WaitForRelease(chart, labelSelector, 120*time.Second, 1)
+			Expect(err).ToNot(HaveOccurred())
+
+			chart, err = framework.GetHelmChart(chart.Name, chart.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+			job, err = framework.GetJob(chart)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("Should have correct container securityContext", func() {
+			Expect(*job.Spec.Template.Spec.Containers[0].SecurityContext).To(Equal(*defaultSecurityContext))
+		})
+		AfterEach(func() {
+			err = framework.DeleteHelmChart(chart.Name, framework.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				_, err := framework.GetHelmChart(chart.Name, framework.Namespace)
+				return err != nil && apierrors.IsNotFound(err)
+			}, 120*time.Second, 5*time.Second).Should(BeTrue())
+		})
 	})
 })


### PR DESCRIPTION
This PR is adding `securityContext` to make the Jobs created by this controller more secure. The default `securityContext` is set to comply with the `Restricted` [Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/) profile but it can be further tweaked via the `podSecurityContext` and the `securityContext`  fields of the `HelmChart` Custom Resource. Jobs created by the controller are further hardened by enabling `readOnlyRootFilesystem` and enabling write access only to `tmpfs` mounts `/home/klipper-helm/.(helm|cache|config)`.