### PR TITLE
Fix issue with ChartContent on read-only rootfs and add e2e test

### DIFF
--- a/pkg/controllers/chart/chart.go
+++ b/pkg/controllers/chart/chart.go
@@ -476,6 +476,10 @@ func job(chart *v1.HelmChart, apiServerPort string) (*batch.Job, *corev1.Secret,
 									Name:      "klipper-config",
 									MountPath: "/home/klipper-helm/.config",
 								},
+								{
+									Name:      "tmp",
+									MountPath: "/tmp",
+								},
 							},
 						},
 					},
@@ -500,6 +504,14 @@ func job(chart *v1.HelmChart, apiServerPort string) (*batch.Job, *corev1.Secret,
 						},
 						{
 							Name: "klipper-config",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									Medium: "Memory",
+								},
+							},
+						},
+						{
+							Name: "tmp",
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									Medium: "Memory",


### PR DESCRIPTION
* Change to enable ReadOnlyRootFS in https://github.com/k3s-io/helm-controller/pull/216 broke ValuesContent, but we didn't notice because we don't have an e2e test for it.