### PR TITLE
Bump klipper-helm image for tls secret support

### DIFF
--- a/pkg/controllers/chart/chart.go
+++ b/pkg/controllers/chart/chart.go
@@ -53,7 +53,7 @@ const (
 var (
 	commaRE              = regexp.MustCompile(`\\*,`)
 	deletePolicy         = metav1.DeletePropagationForeground
-	DefaultJobImage      = "rancher/klipper-helm:v0.8.3-build20240228"
+	DefaultJobImage      = "rancher/klipper-helm:v0.8.4-build20240523"
 	DefaultFailurePolicy = FailurePolicyReinstall
 	defaultBackOffLimit  = pointer.Int32(1000)
 


### PR DESCRIPTION
Currently the `spec.authSecret` must be a [Basic authentication Secret](https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret). This adds support for [TLS Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets).

* https://github.com/k3s-io/k3s/issues/10124

* [x] *waiting on tag CI to finish*