### PR TITLE
Adjust controller lock to be based on controller name

### DIFF
--- a/manifests/deploy-both-cluster-and-namespaced-scoped.yaml
+++ b/manifests/deploy-both-cluster-and-namespaced-scoped.yaml
@@ -1,0 +1,60 @@
+# This is the cluster scoped example - in k3s/RKE2 this is unnecessary as it will be deployed out of the box.
+# To use this example on k3s/RKE2 you should exclude this part, or disable the embedded controller.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helm-controller
+  # Note: This will still deploy to a default namespace
+  labels:
+    app: helm-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: helm-controller
+  template:
+    metadata:
+      labels:
+        app: helm-controller
+    spec:
+      containers:
+        - name: helm-controller
+          image: rancher/helm-controller:v0.12.1
+          command: ["helm-controller"]
+          # Alternatively, on k3s/RKE2, you can deploy an example with 3 instances of helm-controller using:
+          # (The 3 being: k3s/RKE2 built-in helm-controller, this second cluster-scoped with unique name, and final namespace scoped.)
+          # args: ["--controller-name", "second-cluster-scoped-instance"]
+# This section and under are the namespace scoped examples.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: helm-controller
+  labels:
+    name: helm-controller
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helm-controller
+  namespace: helm-controller
+  labels:
+    app: helm-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: helm-controller
+  template:
+    metadata:
+      labels:
+        app: helm-controller
+    spec:
+      containers:
+        - name: helm-controller
+          image: rancher/helm-controller:v0.12.1
+          command: ["helm-controller"]
+          # Note, only one `helm-controller` can have the lock at the same time, so you muse set a unique name.
+          # The default controller-name bust be overridden for both controllers to work at the same time.
+          args: ["--namespace", "helm-controller", "--controller-name", "helm-controller-namespaced"]

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/k3s-io/helm-controller/pkg/controllers/chart"
@@ -106,7 +107,13 @@ func Register(ctx context.Context, systemNamespace, controllerName string, cfg c
 		klog.Infof("Starting helm controller in namespace %s", systemNamespace)
 	}
 
-	leader.RunOrDie(ctx, systemNamespace, "helm-controller-lock", appCtx.K8s, func(ctx context.Context) {
+	controllerLockName := "helm-controller-lock"
+	if controllerName != "helm-controller" {
+		klog.Infof("Starting helm controller using alias `%s`", controllerName)
+		controllerLockName = strings.Join([]string{controllerName, controllerLockName}, "-")
+	}
+
+	leader.RunOrDie(ctx, systemNamespace, controllerLockName, appCtx.K8s, func(ctx context.Context) {
 		if err := appCtx.start(ctx); err != nil {
 			klog.Fatal(err)
 		}


### PR DESCRIPTION
This PR was created while exploring solutions to an issue with Prometheus Federator's usage for `helm-controller`. More context here: https://github.com/rancher/prometheus-federator/pull/141#discussion_r1917425291

From what I've found the lock mechanism is one of the remaining changes needed to more elegantly support - for lack of better term - "multiple helm-controllers in a single cluster". Our use case is specific to PromFed, however I suspect it's better to generalize the idea of supporting this since that has the same challenges and doesn't involve the external project.