### PR TITLE
Bump DefaultJobImage to 20250306

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -7,7 +7,7 @@ RUN apk -U add bash git gcc musl-dev docker vim less file curl wget ca-certifica
 RUN GOPROXY=direct go install golang.org/x/tools/cmd/goimports@gopls/v0.8.2
 
 RUN if [ "${ARCH}" == "amd64" ]; then \
-        curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/v1.52.2/install.sh | sh -s; \
+        curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/refs/tags/v1.64.8/install.sh | sh -s -- v1.64.8;  \
         go install sigs.k8s.io/kustomize/kustomize/v4@v4.5.7; \
     fi
 

--- a/pkg/controllers/chart/chart.go
+++ b/pkg/controllers/chart/chart.go
@@ -53,7 +53,7 @@ const (
 var (
 	commaRE              = regexp.MustCompile(`\\*,`)
 	deletePolicy         = metav1.DeletePropagationForeground
-	DefaultJobImage      = "rancher/klipper-helm:v0.9.4-build20250113"
+	DefaultJobImage      = "rancher/klipper-helm:v0.9.5-build20250306"
 	DefaultFailurePolicy = FailurePolicyReinstall
 	defaultBackOffLimit  = pointer.Int32(1000)
 


### PR DESCRIPTION
Also pin golangci-lint to last version that supports older golang 1.22. New releases are not backwards compatible. 