### PR TITLE
Set the DefaultJobImage to latest.

### DIFF
--- a/pkg/controllers/chart/chart.go
+++ b/pkg/controllers/chart/chart.go
@@ -58,7 +58,7 @@ const (
 var (
 	commaRE              = regexp.MustCompile(`\\*,`)
 	deletePolicy         = metav1.DeletePropagationForeground
-	DefaultJobImage      = "rancher/klipper-helm:v0.9.10-build20251111"
+	DefaultJobImage      = "rancher/klipper-helm:latest"
 	DefaultFailurePolicy = FailurePolicyReinstall
 	defaultBackOffLimit  = ptr.To(int32(1000))
 


### PR DESCRIPTION
We have for about 3 months been publishing the klipper-helm image with a latest tag in Dockerhub. This allows us to simplify our golang update to the helm-controller repo. We can seperate the need to bump helm-controller from klipper-helm image bump. 

Standalone control of the image is still avalaible via the `default-job-image` flag.

Signed-off-by: Derek Nola <derek.nola@suse.com>