### PR TITLE
Add a large upper resource limit for install jobs

### DIFF
--- a/pkg/controllers/chart/chart.go
+++ b/pkg/controllers/chart/chart.go
@@ -638,6 +638,10 @@ func job(chart *v1.HelmChart, apiServerPort string) (*batch.Job, *corev1.Secret,
 								},
 							},
 							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("0.1"),
+									corev1.ResourceMemory: resource.MustParse("10M"),
+								},
 								Limits: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("32"),
 									corev1.ResourceMemory: resource.MustParse("32G"),

--- a/pkg/controllers/chart/chart.go
+++ b/pkg/controllers/chart/chart.go
@@ -80,6 +80,7 @@ var (
 		},
 		ReadOnlyRootFilesystem: ptr.To(true),
 	}
+	defaultPriorityClassName = "system-cluster-critical"
 )
 
 type Controller struct {
@@ -670,6 +671,7 @@ func job(chart *v1.HelmChart, apiServerPort string) (*batch.Job, *corev1.Secret,
 					},
 					ServiceAccountName: fmt.Sprintf("helm-%s", chart.Name),
 					SecurityContext:    podSecurityContext,
+					PriorityClassName:  defaultPriorityClassName,
 					Volumes: []corev1.Volume{
 						{
 							Name: "klipper-helm",

--- a/pkg/controllers/chart/chart.go
+++ b/pkg/controllers/chart/chart.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -634,6 +635,12 @@ func job(chart *v1.HelmChart, apiServerPort string) (*batch.Job, *corev1.Secret,
 								{
 									Name:  "PLAIN_HTTP",
 									Value: fmt.Sprintf("%t", chart.Spec.PlainHTTP),
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("32"),
+									corev1.ResourceMemory: resource.MustParse("32G"),
 								},
 							},
 							SecurityContext: securityContext,

--- a/pkg/controllers/chart/chart_test.go
+++ b/pkg/controllers/chart/chart_test.go
@@ -128,6 +128,8 @@ func TestInstallJob(t *testing.T) {
 	assert.Equal("helm-install-traefik", job.Name)
 	assert.Equal(DefaultJobImage, job.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal("helm-traefik", job.Spec.Template.Spec.ServiceAccountName)
+	assert.Equal("32", job.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String())
+	assert.Equal("32G", job.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String())
 }
 
 func TestDeleteJob(t *testing.T) {


### PR DESCRIPTION
Some policy controllers like OPA Gatekeeper require containers to have "some" resource limit to run. Adding a large upper limit to the helm-install jobs ensures minimal compliance. We do not expect the install jobs to take more then a few seconds and a few megabytes of memory as they are very simple `helm install XXXX` commands internally. 


Signed-off-by: Derek Nola <derek.nola@suse.com>