### PR TITLE
Add configurable Helm storage driver to HelmChart spec

### DIFF
--- a/doc/helmchart.md
+++ b/doc/helmchart.md
@@ -162,6 +162,7 @@ _Appears in:_
 | `dockerRegistrySecret` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#localobjectreference-v1-core)_ | Reference to Secret of type kubernetes.io/dockerconfigjson holding Docker auth credentials for the OCI-based registry acting as the Chart repo. |  |  |
 | `podSecurityContext` _[PodSecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podsecuritycontext-v1-core)_ | Custom PodSecurityContext for the helm job pod. |  |  |
 | `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#securitycontext-v1-core)_ | custom SecurityContext for the helm job pod. |  |  |
+| `driver` _[HelmDriver](#helmdriver)_ | Helm storage driver to use for this chart's release metadata.<br />`secret` stores releases in Kubernetes Secrets (default).<br />`configmap` stores releases in ConfigMaps.<br />This field is effectively immutable after the first install; changing the storage backend is not a supported migration path.<br />Helm CLI environment variable: `HELM_DRIVER` | secret | Enum: [secret configmap] <br /> |
 
 
 #### HelmChartStatus
@@ -179,6 +180,20 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `jobName` _string_ | The name of the job created to install or upgrade the chart. |  |  |
 | `conditions` _[HelmChartCondition](#helmchartcondition) array_ | `JobCreated` indicates that a job has been created to install or upgrade the chart.<br />`Failed` indicates that the helm job has failed and the failure policy is set to `abort`. |  |  |
+
+
+#### HelmDriver
+
+_Underlying type:_ _string_
+
+
+
+_Validation:_
+- Enum: [secret configmap]
+
+_Appears in:_
+- [HelmChartSpec](#helmchartspec)
+
 
 
 #### SecretSpec

--- a/pkg/apis/helm.cattle.io/v1/types.go
+++ b/pkg/apis/helm.cattle.io/v1/types.go
@@ -13,6 +13,9 @@ import (
 // +kubebuilder:validation:Enum={"abort","reinstall"}
 type FailurePolicy string
 
+// +kubebuilder:validation:Enum={"secret","configmap"}
+type HelmDriver string
+
 // +genclient
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=hc
@@ -108,6 +111,14 @@ type HelmChartSpec struct {
 	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
 	// custom SecurityContext for the helm job pod.
 	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
+	// Helm storage driver to use for this chart's release metadata.
+	// `secret` stores releases in Kubernetes Secrets (default).
+	// `configmap` stores releases in ConfigMaps.
+	// This field is effectively immutable after the first install; changing the storage backend is not a supported migration path.
+	// Helm CLI environment variable: `HELM_DRIVER`
+	// +kubebuilder:default=secret
+	// +kubebuilder:validation:XValidation:rule="!oldSelf.hasValue() || self == oldSelf.value()",message="driver is immutable after creation",optionalOldSelf=true
+	Driver HelmDriver `json:"driver,omitempty"`
 }
 
 // HelmChartStatus represents the resulting state from processing HelmChart events

--- a/pkg/controllers/chart/chart.go
+++ b/pkg/controllers/chart/chart.go
@@ -105,11 +105,20 @@ type Controller struct {
 	confCache       helmcontroller.HelmChartConfigCache
 	jobs            batchcontroller.JobController
 	jobCache        batchcontroller.JobCache
-	secrets         corecontroller.SecretController
+	configMaps      configMapLister
+	secrets         secretLister
 	secretCache     corecontroller.SecretCache
 	apply           apply.Apply
 	recorder        record.EventRecorder
 	apiServerPort   string
+}
+
+type configMapLister interface {
+	List(namespace string, opts metav1.ListOptions) (*corev1.ConfigMapList, error)
+}
+
+type secretLister interface {
+	List(namespace string, opts metav1.ListOptions) (*corev1.SecretList, error)
 }
 
 func Register(
@@ -142,6 +151,7 @@ func Register(
 		confCache:       confCache,
 		jobs:            jobs,
 		jobCache:        jobCache,
+		configMaps:      cm,
 		secrets:         s,
 		secretCache:     sCache,
 		recorder:        recorder,
@@ -565,20 +575,40 @@ func (c *Controller) getJobAndRelatedResources(chart *v1.HelmChart) (*batch.Job,
 }
 
 func (c *Controller) getChartReleaseRevision(chart *v1.HelmChart) (int64, error) {
-	var version int64
-	fs := fields.OneTermEqualSelector("type", ReleaseType)
 	ls := labels.Set{"owner": "helm", "name": chart.Name}.AsSelector()
+
+	if helmDriver(chart) == "configmap" {
+		cmList, err := c.configMaps.List(chart.Spec.TargetNamespace, metav1.ListOptions{LabelSelector: ls.String()})
+		if err != nil {
+			return 0, err
+		}
+		objects := make([]metav1.ObjectMeta, len(cmList.Items))
+		for i := range cmList.Items {
+			objects[i] = cmList.Items[i].ObjectMeta
+		}
+		return maxReleaseRevision(objects), nil
+	}
+
+	fs := fields.OneTermEqualSelector("type", ReleaseType)
 	secretList, err := c.secrets.List(chart.Spec.TargetNamespace, metav1.ListOptions{FieldSelector: fs.String(), LabelSelector: ls.String()})
 	if err != nil {
-		return version, err
+		return 0, err
 	}
-	for _, secret := range secretList.Items {
-		if sv, err := strconv.ParseInt(secret.ObjectMeta.Labels["version"], 10, 64); err == nil && sv > version {
+	objects := make([]metav1.ObjectMeta, len(secretList.Items))
+	for i := range secretList.Items {
+		objects[i] = secretList.Items[i].ObjectMeta
+	}
+	return maxReleaseRevision(objects), nil
+}
+
+func maxReleaseRevision(objects []metav1.ObjectMeta) int64 {
+	var version int64
+	for _, obj := range objects {
+		if sv, err := strconv.ParseInt(obj.Labels["version"], 10, 64); err == nil && sv > version {
 			version = sv
 		}
 	}
-
-	return version, nil
+	return version
 }
 
 func chartBySecret(chart *v1.HelmChart) ([]string, error) {
@@ -668,7 +698,7 @@ func job(chart *v1.HelmChart, apiServerPort string) (*batch.Job, *corev1.Secret,
 								},
 								{
 									Name:  "HELM_DRIVER",
-									Value: "secret",
+									Value: helmDriver(chart),
 								},
 								{
 									Name:  "CHART_NAMESPACE",
@@ -1327,6 +1357,13 @@ func templateChanged(oldJob, newJob *batch.Job) bool {
 		}
 	}
 	return !equality.Semantic.DeepEqual(oldPodTemplate, newPodTemplate)
+}
+
+func helmDriver(chart *v1.HelmChart) string {
+	if chart.Spec.Driver != "" {
+		return string(chart.Spec.Driver)
+	}
+	return "secret"
 }
 
 func objectToJob(obj runtime.Object) (*batch.Job, error) {

--- a/pkg/controllers/chart/chart_test.go
+++ b/pkg/controllers/chart/chart_test.go
@@ -11,7 +11,10 @@ import (
 	"github.com/rancher/wrangler/v3/pkg/yaml"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -197,6 +200,146 @@ func TestDeleteArgs(t *testing.T) {
 	chart.DeletionTimestamp = &deleteTime
 	stringArgs := strings.Join(args(chart), " ")
 	assert.Equal("delete", stringArgs)
+}
+
+func TestDriverField(t *testing.T) {
+	tests := []struct {
+		name     string
+		driver   v1.HelmDriver
+		expected string
+	}{
+		{"default driver", "", "secret"},
+		{"secret driver", "secret", "secret"},
+		{"configmap driver", "configmap", "configmap"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			chart := NewChart()
+			chart.Spec.Driver = tt.driver
+			j, _, _ := job(chart, "6443")
+			envs := j.Spec.Template.Spec.Containers[0].Env
+			var helmDriver string
+			for _, e := range envs {
+				if e.Name == "HELM_DRIVER" {
+					helmDriver = e.Value
+					break
+				}
+			}
+			assert.Equal(tt.expected, helmDriver)
+		})
+	}
+}
+
+func TestMaxReleaseRevision(t *testing.T) {
+	tests := []struct {
+		name     string
+		objects  []metav1.ObjectMeta
+		expected int64
+	}{
+		{"no objects", nil, 0},
+		{"single revision", []metav1.ObjectMeta{
+			{Labels: map[string]string{"version": "1"}},
+		}, 1},
+		{"multiple revisions returns max", []metav1.ObjectMeta{
+			{Labels: map[string]string{"version": "1"}},
+			{Labels: map[string]string{"version": "3"}},
+			{Labels: map[string]string{"version": "2"}},
+		}, 3},
+		{"invalid version label ignored", []metav1.ObjectMeta{
+			{Labels: map[string]string{"version": "abc"}},
+			{Labels: map[string]string{"version": "2"}},
+		}, 2},
+		{"missing version label ignored", []metav1.ObjectMeta{
+			{Labels: map[string]string{"owner": "helm"}},
+			{Labels: map[string]string{"version": "5"}},
+		}, 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			assert.Equal(tt.expected, maxReleaseRevision(tt.objects))
+		})
+	}
+}
+
+func TestGetChartReleaseRevision(t *testing.T) {
+	t.Run("configmap driver uses configmap storage", func(t *testing.T) {
+		assert := assert.New(t)
+		var called bool
+		c := &Controller{
+			configMaps: fakeConfigMapLister{
+				list: func(namespace string, opts metav1.ListOptions) (*corev1.ConfigMapList, error) {
+					called = true
+					assert.Equal("target-ns", namespace)
+					assert.Equal(labels.Set{"owner": "helm", "name": "traefik"}.AsSelector().String(), opts.LabelSelector)
+					assert.Empty(opts.FieldSelector)
+					return &corev1.ConfigMapList{
+						Items: []corev1.ConfigMap{
+							{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"version": "1"}}},
+							{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"version": "3"}}},
+						},
+					}, nil
+				},
+			},
+		}
+
+		chart := NewChart()
+		chart.Spec.Driver = "configmap"
+		chart.Spec.TargetNamespace = "target-ns"
+
+		revision, err := c.getChartReleaseRevision(chart)
+		assert.NoError(err)
+		assert.True(called)
+		assert.Equal(int64(3), revision)
+	})
+
+	t.Run("default driver uses secret storage", func(t *testing.T) {
+		assert := assert.New(t)
+		var called bool
+		c := &Controller{
+			secrets: fakeSecretLister{
+				list: func(namespace string, opts metav1.ListOptions) (*corev1.SecretList, error) {
+					called = true
+					assert.Equal("target-ns", namespace)
+					assert.Equal(labels.Set{"owner": "helm", "name": "traefik"}.AsSelector().String(), opts.LabelSelector)
+					assert.Equal(fields.OneTermEqualSelector("type", ReleaseType).String(), opts.FieldSelector)
+					return &corev1.SecretList{
+						Items: []corev1.Secret{
+							{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"version": "2"}}},
+							{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"version": "5"}}},
+						},
+					}, nil
+				},
+			},
+		}
+
+		chart := NewChart()
+		chart.Spec.TargetNamespace = "target-ns"
+
+		revision, err := c.getChartReleaseRevision(chart)
+		assert.NoError(err)
+		assert.True(called)
+		assert.Equal(int64(5), revision)
+	})
+}
+
+type fakeConfigMapLister struct {
+	list func(namespace string, opts metav1.ListOptions) (*corev1.ConfigMapList, error)
+}
+
+func (f fakeConfigMapLister) List(namespace string, opts metav1.ListOptions) (*corev1.ConfigMapList, error) {
+	return f.list(namespace, opts)
+}
+
+type fakeSecretLister struct {
+	list func(namespace string, opts metav1.ListOptions) (*corev1.SecretList, error)
+}
+
+func (f fakeSecretLister) List(namespace string, opts metav1.ListOptions) (*corev1.SecretList, error) {
+	return f.list(namespace, opts)
 }
 
 func NewChart() *v1.HelmChart {

--- a/pkg/crds/yaml/generated/helm.cattle.io_helmcharts.yaml
+++ b/pkg/crds/yaml/generated/helm.cattle.io_helmcharts.yaml
@@ -126,6 +126,22 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              driver:
+                default: secret
+                description: |-
+                  Helm storage driver to use for this chart's release metadata.
+                  `secret` stores releases in Kubernetes Secrets (default).
+                  `configmap` stores releases in ConfigMaps.
+                  This field is effectively immutable after the first install; changing the storage backend is not a supported migration path.
+                  Helm CLI environment variable: `HELM_DRIVER`
+                enum:
+                - secret
+                - configmap
+                type: string
+                x-kubernetes-validations:
+                - message: driver is immutable after creation
+                  optionalOldSelf: true
+                  rule: '!oldSelf.hasValue() || self == oldSelf.value()'
               failurePolicy:
                 default: reinstall
                 description: |-

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -158,7 +158,7 @@ func (f *Framework) NewHelmChartConfig(name, values, valuesContent string) *v1.H
 	}
 }
 
-func (f *Framework) ListReleases(chart *v1.HelmChart) ([]corev1.Secret, error) {
+func (f *Framework) ListSecretReleases(chart *v1.HelmChart) ([]corev1.Secret, error) {
 	labelSelector := labels.SelectorFromSet(labels.Set{
 		"owner": "helm",
 		"name":  chart.Name,
@@ -178,6 +178,27 @@ func (f *Framework) ListReleases(chart *v1.HelmChart) ([]corev1.Secret, error) {
 	}
 
 	return secretList.Items, nil
+}
+
+func (f *Framework) ListConfigMapReleases(chart *v1.HelmChart) ([]corev1.ConfigMap, error) {
+	labelSelector := labels.SelectorFromSet(labels.Set{
+		"owner": "helm",
+		"name":  chart.Name,
+	})
+	namespace := chart.Namespace
+	if chart.Spec.TargetNamespace != "" {
+		namespace = chart.Spec.TargetNamespace
+	}
+
+	cmList, err := f.ClientSet.CoreV1().ConfigMaps(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return cmList.Items, nil
 }
 
 // GetDeployedRelease fetches the secret containing meta data about the currently deployed helm release.

--- a/test/suite/helm_test.go
+++ b/test/suite/helm_test.go
@@ -49,7 +49,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 		})
 
 		It("Should create a release for the chart", func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
 		})
 
 		AfterAll(func() {
@@ -60,7 +60,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 		})
 	})
 
@@ -90,7 +90,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should create a release for the chart", func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
 		})
 		It("Should create a new release when the version is changed", func() {
 			chart, err = framework.GetHelmChart(chart.Name, chart.Namespace)
@@ -100,7 +100,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Expect(chart.Spec.Version).To(Equal("1.86.2"))
 
 			// check for 2 releases, and pod with image specified by new chart version
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(2))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(2))
 			Eventually(framework.ListChartPods, 120*time.Second, 5*time.Second).WithArguments(chart, "traefik").Should(
 				ContainElement(HaveField("Status.ContainerStatuses", ContainElements(HaveField("Image", ContainSubstring("docker.io/rancher/library-traefik:1.7.20"))))),
 			)
@@ -113,7 +113,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 		})
 	})
 
@@ -143,7 +143,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should create a release for the chart", func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
 		})
 		It("Should create a new release when the values are changed", func() {
 			chart, err = framework.GetHelmChart(chart.Name, chart.Namespace)
@@ -152,7 +152,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(chart.Spec.Set["replicas"]).To(Equal(intstr.FromString("3")))
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(2))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(2))
 		})
 		AfterAll(func() {
 			err = framework.DeleteHelmChart(chart.Name, chart.Namespace)
@@ -162,7 +162,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 		})
 	})
 
@@ -208,7 +208,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 		})
 
 		It("Should create a release for the chart", func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
 		})
 
 		It("Should take ownership of existing resources", func() {
@@ -227,7 +227,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 		})
 	})
 
@@ -260,7 +260,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should create a release for the chart", func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
 		})
 		It("Should have the correct timeout", func() {
 			chart, err = framework.GetHelmChart(chart.Name, chart.Namespace)
@@ -283,7 +283,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 		})
 	})
 
@@ -316,7 +316,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should create a release for the chart", func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
 		})
 		AfterAll(func() {
 			err = framework.DeleteHelmChart(chart.Name, chart.Namespace)
@@ -326,7 +326,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 		})
 	})
 
@@ -348,14 +348,14 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should create a release for the chart", func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
 		})
 		It("Should create a new release when the HelmChartConfig is created", func() {
 			chartConfig = framework.NewHelmChartConfig(chart.Name, "", "metrics:\n  prometheus:\n    enabled: true\nkubernetes:\n  ingressEndpoint:\n    useDefaultPublishedService: true\nimage: docker.io/rancher/library-traefik\n")
 			chartConfig, err = framework.CreateHelmChartConfig(chartConfig, framework.Namespace)
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(2))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(2))
 		})
 		AfterAll(func() {
 			err = framework.DeleteHelmChart(chart.Name, chart.Namespace)
@@ -368,7 +368,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 		})
 	})
 
@@ -392,7 +392,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should create a release for the chart with all values in the expected precedence (set > values > valuesContent)", func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
 
 			config, err := framework.GetDeployedReleaseConfig(chart)
 			Expect(err).ToNot(HaveOccurred())
@@ -414,7 +414,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			chartConfig, err = framework.CreateHelmChartConfig(chartConfig, framework.Namespace)
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(2))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(2))
 
 			config, err := framework.GetDeployedReleaseConfig(chart)
 			Expect(err).ToNot(HaveOccurred())
@@ -439,7 +439,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 		})
 	})
 
@@ -481,7 +481,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should create a release for the chart", func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
 		})
 		It("Should create a new release when the secret is modified", func() {
 			userSecret.Data = nil
@@ -491,7 +491,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			userSecret, err = framework.ClientSet.CoreV1().Secrets(userSecret.Namespace).Update(context.TODO(), userSecret, metav1.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(2))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(2))
 		})
 		AfterAll(func() {
 			err = framework.DeleteHelmChart(chart.Name, chart.Namespace)
@@ -501,7 +501,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 
 			err = framework.ClientSet.CoreV1().Secrets(userSecret.Namespace).Delete(context.TODO(), userSecret.Name, metav1.DeleteOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -527,7 +527,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should create a release for the chart", func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
 		})
 		It("Should create a new release when the HelmChartConfig is created", func() {
 			userSecret = &corev1.Secret{
@@ -554,7 +554,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			chartConfig, err = framework.CreateHelmChartConfig(chartConfig, framework.Namespace)
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(2))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(2))
 		})
 		It("Should create a new release when the secret is modified", func() {
 			userSecret.Data = nil
@@ -564,7 +564,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			userSecret, err = framework.ClientSet.CoreV1().Secrets(userSecret.Namespace).Update(context.TODO(), userSecret, metav1.UpdateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(3))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(3))
 		})
 
 		AfterAll(func() {
@@ -578,7 +578,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 		})
 	})
 
@@ -610,7 +610,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should create a release for the chart in the target namespace", func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(
 				And(
 					HaveLen(1),
 					ContainElement(HaveField("ObjectMeta.Namespace", Equal(chart.Spec.TargetNamespace))),
@@ -624,7 +624,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 		})
 	})
 
@@ -657,7 +657,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should create a release for the chart", func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
 		})
 		It("Should be possible to delete the namespace", func() {
 			err = framework.DeleteNamespace(chart.Namespace, true)
@@ -665,7 +665,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Eventually(framework.ListNamespaces, 120*time.Second, 5*time.Second).WithArguments(chart.Namespace).Should(BeEmpty())
 		})
 		AfterAll(func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 		})
 	})
 
@@ -714,7 +714,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 		})
 	})
 
@@ -748,7 +748,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should create a release for the chart", func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
 		})
 		It("Should have correct job backOff Limit", func() {
 			chart, err = framework.GetHelmChart(chart.Name, chart.Namespace)
@@ -766,7 +766,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 		})
 	})
 
@@ -800,7 +800,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should create a release for the chart", func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
 		})
 		It("Should have correct job backOff Limit", func() {
 			chart, err = framework.GetHelmChart(chart.Name, chart.Namespace)
@@ -818,7 +818,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 		})
 	})
 
@@ -855,7 +855,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should create a release for the chart", func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
 		})
 		It("Should have correct pod securityContext", func() {
 			chart, err = framework.GetHelmChart(chart.Name, chart.Namespace)
@@ -873,7 +873,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 		})
 	})
 
@@ -910,7 +910,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should create a release for the chart", func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
 		})
 		It("Should have correct pod securityContext", func() {
 			chart, err = framework.GetHelmChart(chart.Name, chart.Namespace)
@@ -928,7 +928,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 		})
 	})
 
@@ -965,7 +965,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should create a release for the chart", func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
 		})
 		It("Should have correct container securityContext", func() {
 			chart, err = framework.GetHelmChart(chart.Name, chart.Namespace)
@@ -983,7 +983,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 		})
 	})
 
@@ -1023,7 +1023,7 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should create a release for the chart", func() {
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
 		})
 		It("Should have correct container securityContext", func() {
 			chart, err = framework.GetHelmChart(chart.Name, chart.Namespace)
@@ -1041,7 +1041,78 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
 			}, 120*time.Second, 5*time.Second).Should(Succeed())
 
-			Eventually(framework.ListReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+		})
+	})
+
+	Context("When a HelmChart uses the configmap storage driver", func() {
+		var (
+			err   error
+			chart *v1.HelmChart
+		)
+		BeforeAll(func() {
+			chart = framework.NewHelmChart("traefik-configmap-driver",
+				"stable/traefik",
+				"1.86.1",
+				"v3",
+				"",
+				"metrics:\n  prometheus:\n    enabled: true\nkubernetes:\n  ingressEndpoint:\n    useDefaultPublishedService: true\nimage: docker.io/rancher/library-traefik\n",
+				map[string]intstr.IntOrString{
+					"rbac.enabled": {
+						Type:   intstr.String,
+						StrVal: "true",
+					},
+					"ssl.enabled": {
+						Type:   intstr.String,
+						StrVal: "true",
+					},
+				})
+			chart.Spec.Driver = "configmap"
+			chart, err = framework.CreateHelmChart(chart, framework.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Should create a release stored as a ConfigMap", func() {
+			Eventually(framework.ListConfigMapReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(1))
+		})
+
+		It("Should have no release stored as a Secret", func() {
+			Consistently(framework.ListSecretReleases, 10*time.Second, 2*time.Second).WithArguments(chart).Should(HaveLen(0))
+		})
+
+		It("Should create a new ConfigMap release when values are changed", func() {
+			chart, err = framework.GetHelmChart(chart.Name, chart.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+			chart.Spec.Set["replicas"] = intstr.FromString("3")
+			chart, err = framework.UpdateHelmChart(chart, chart.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(framework.ListConfigMapReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(2))
+		})
+
+		It("Should set HELM_DRIVER=configmap on the job", func() {
+			chart, err = framework.GetHelmChart(chart.Name, chart.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			job, err := framework.GetJob(chart)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(job.Spec.Template.Spec.Containers[0].Env).To(ContainElement(
+				And(
+					HaveField("Name", "HELM_DRIVER"),
+					HaveField("Value", "configmap"),
+				),
+			))
+		})
+
+		AfterAll(func() {
+			err = framework.DeleteHelmChart(chart.Name, chart.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				g.Expect(framework.GetHelmChart(chart.Name, chart.Namespace)).Error().Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+			}, 120*time.Second, 5*time.Second).Should(Succeed())
+
+			Eventually(framework.ListConfigMapReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Add a `spec.driver` field to the HelmChart CRD to allow configuring the Helm storage driver (`HELM_DRIVER` env var). Currently hardcoded to `"secret"`.

Both Secrets and ConfigMaps share the same 1MB Kubernetes API server limit, but Secrets incur base64 encoding overhead that reduces effective capacity to ~750KB. Using `configmap` avoids this overhead, allowing larger releases (e.g. `traefik-crds` with Gateway API CRDs, `prometheus-operator-crds`) to fit within the same limit.

Accepted values: `secret` (default, backward-compatible), `configmap`.

> Note: Helm also supports `memory` and `sql` drivers, but these are not included here. `memory` is incompatible with the job-based execution model (each helm command runs as a separate process, so in-memory state is lost between commands). `sql` requires additional env vars (`HELM_DRIVER_SQL_CONNECTION_STRING`) that cannot currently be passed to the job pod. Both can be added in follow-up PRs if needed.

## Changes

- Added `HelmDriver` validated enum type and `Driver` field to `HelmChartSpec`
- Replaced hardcoded `"secret"` with `helmDriver()` helper in `chart.go` (defaults to `"secret"` when field is empty)
- Made `getChartReleaseRevision()` driver-aware looks up ConfigMaps when `driver=configmap`, preserving the `EXPECTED_RELEASE_REVISION` revision guard
- Added `TestDriverField`, `TestMaxReleaseRevision`, and `TestGetChartReleaseRevision` tests
- Regenerated CRD YAML and reference docs

## Example usage

```yaml
apiVersion: helm.cattle.io/v1
kind: HelmChart
metadata:
  name: traefik-crds
  namespace: kube-system
spec:
  driver: configmap
  chart: traefik-crds
  repo: https://traefik.github.io/charts
```

## Notes

- Field NOT added to `HelmChartConfigSpec` changing storage driver mid-lifecycle is destructive and should require explicit action on the HelmChart itself
- `+kubebuilder:default=secret` ensures backward compatibility for existing resources
- `driver` field is immutable after creation via CEL validation (`x-kubernetes-validations`), preventing accidental loss of release metadata from switching storage backends

## Follow-up

- `spec.driver` currently supports `secret` and `configmap`, which covers the original issue and keeps the change small and focused.
- SQL storage is intentionally not included in this PR. Supporting `sql` cleanly would require additional API design and controller wiring, including how to provide `HELM_DRIVER_SQL_CONNECTION_STRING` securely and how that configuration should be validated and documented.
- `memory` driver is not included because it is incompatible with the job-based execution model. Each helm command runs as a separate process in the job pod, so in-memory release state is lost between commands.
- The `driver` field is currently immutable via CEL validation. A future improvement could support driver migration by detecting driver changes and migrating release metadata between backends.

Fixes #317