### PR TITLE
Allow disabling pod limits

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,13 @@ func main() {
 				Usage:       "If debugging is enabled, set klog -v=X",
 				Destination: &config.DebugLevel,
 			},
+			&cli.BoolFlag{
+				Name:        "enforce-pod-limits",
+				Value:       true,
+				Usage:       "Set to false to disable default CPU and memory limits on the pods created to manage helm charts",
+				EnvVars:     []string{"ENFORCE_POD_LIMITS"},
+				Destination: &config.EnforcePodLimits,
+			},
 			&cli.StringFlag{
 				Name:        "default-job-image",
 				Usage:       "Default image to use by jobs managing helm charts",

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -29,18 +29,19 @@ const (
 )
 
 type HelmController struct {
-	Debug           bool
-	DebugLevel      int
-	Kubeconfig      string
-	MasterURL       string
-	Namespace       string
-	Threads         int
-	ControllerName  string
-	NodeName        string
-	JobClusterRole  string
-	DefaultJobImage string
-	JobTolerations  string
-	PprofPort       int
+	Debug            bool
+	DebugLevel       int
+	Kubeconfig       string
+	MasterURL        string
+	Namespace        string
+	Threads          int
+	ControllerName   string
+	NodeName         string
+	JobClusterRole   string
+	DefaultJobImage  string
+	JobTolerations   string
+	EnforcePodLimits bool
+	PprofPort        int
 }
 
 func (hc *HelmController) SetupLogging() (logr.Logger, error) {
@@ -88,11 +89,12 @@ func (hc *HelmController) Run(app *cli.Context) error {
 	}
 
 	opts := common.Options{
-		Threadiness:     hc.Threads,
-		NodeName:        hc.NodeName,
-		JobClusterRole:  hc.JobClusterRole,
-		DefaultJobImage: hc.DefaultJobImage,
-		JobTolerations:  tolerations,
+		Threadiness:      hc.Threads,
+		NodeName:         hc.NodeName,
+		JobClusterRole:   hc.JobClusterRole,
+		DefaultJobImage:  hc.DefaultJobImage,
+		JobTolerations:   tolerations,
+		EnforcePodLimits: hc.EnforcePodLimits,
 	}
 
 	if err := opts.Validate(); err != nil {

--- a/pkg/controllers/chart/chart.go
+++ b/pkg/controllers/chart/chart.go
@@ -70,12 +70,23 @@ const (
 )
 
 var (
-	commaRE              = regexp.MustCompile(`\\*,`)
-	DefaultJobImage      = "rancher/klipper-helm:latest"
-	JobTolerations       []corev1.Toleration
-	DefaultFailurePolicy = FailurePolicyReinstall
-	defaultBackOffLimit  = ptr.To(int32(1000))
-	jobSettleTime        = time.Second * 3
+	commaRE                        = regexp.MustCompile(`\\*,`)
+	DefaultJobImage                = "rancher/klipper-helm:latest"
+	EnforcePodLimits               = true
+	JobTolerations                 []corev1.Toleration
+	DefaultFailurePolicy           = FailurePolicyReinstall
+	defaultBackOffLimit            = ptr.To(int32(1000))
+	jobSettleTime                  = time.Second * 3
+	defaultJobResourceRequirements = &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("0.1"),
+			corev1.ResourceMemory: resource.MustParse("10M"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("32"),
+			corev1.ResourceMemory: resource.MustParse("32G"),
+		},
+	}
 
 	defaultPodSecurityContext = &corev1.PodSecurityContext{
 		RunAsNonRoot: ptr.To(true),
@@ -729,16 +740,6 @@ func job(chart *v1.HelmChart, apiServerPort string) (*batch.Job, *corev1.Secret,
 									Value: fmt.Sprintf("%t", chart.Spec.PlainHTTP),
 								},
 							},
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("0.1"),
-									corev1.ResourceMemory: resource.MustParse("10M"),
-								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("32"),
-									corev1.ResourceMemory: resource.MustParse("32G"),
-								},
-							},
 							SecurityContext: securityContext,
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -862,6 +863,7 @@ func job(chart *v1.HelmChart, apiServerPort string) (*batch.Job, *corev1.Secret,
 	setAuthSecret(job, chart)
 	setDockerRegistrySecret(job, chart)
 	setRepoCAConfigMap(job, chart)
+	setPodLimits(job)
 	setSecurityContext(job, chart)
 	setTolerations(job)
 	valuesSecret := setValuesSecret(job, chart)
@@ -1292,6 +1294,15 @@ func hashObjects(job *batch.Job, objs ...metav1.Object) {
 
 func setBackOffLimit(job *batch.Job, backOffLimit *int32) {
 	job.Spec.BackoffLimit = backOffLimit
+}
+
+func setPodLimits(job *batch.Job) {
+	if !EnforcePodLimits {
+		job.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{}
+		return
+	}
+
+	job.Spec.Template.Spec.Containers[0].Resources = *defaultJobResourceRequirements.DeepCopy()
 }
 
 func setSecurityContext(job *batch.Job, chart *v1.HelmChart) {

--- a/pkg/controllers/chart/chart_test.go
+++ b/pkg/controllers/chart/chart_test.go
@@ -155,6 +155,10 @@ func TestSetVals(t *testing.T) {
 
 func TestInstallJob(t *testing.T) {
 	assert := assert.New(t)
+	oldEnforcePodLimits := EnforcePodLimits
+	defer func() { EnforcePodLimits = oldEnforcePodLimits }()
+	EnforcePodLimits = true
+
 	chart := NewChart()
 	job, _, _ := job(chart, "6443")
 	assert.Equal("helm-install-traefik", job.Name)
@@ -162,6 +166,18 @@ func TestInstallJob(t *testing.T) {
 	assert.Equal("helm-traefik", job.Spec.Template.Spec.ServiceAccountName)
 	assert.Equal("32", job.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String())
 	assert.Equal("32G", job.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String())
+}
+
+func TestInstallJobWithoutPodLimits(t *testing.T) {
+	assert := assert.New(t)
+	oldEnforcePodLimits := EnforcePodLimits
+	defer func() { EnforcePodLimits = oldEnforcePodLimits }()
+	EnforcePodLimits = false
+
+	chart := NewChart()
+	job, _, _ := job(chart, "6443")
+	assert.Empty(job.Spec.Template.Spec.Containers[0].Resources.Requests)
+	assert.Empty(job.Spec.Template.Spec.Containers[0].Resources.Limits)
 }
 
 func TestDeleteJob(t *testing.T) {

--- a/pkg/controllers/common/options.go
+++ b/pkg/controllers/common/options.go
@@ -8,11 +8,12 @@ import (
 
 // Options defines options that can be set on initializing the Helm Controller
 type Options struct {
-	Threadiness     int
-	NodeName        string
-	JobClusterRole  string
-	DefaultJobImage string
-	JobTolerations  []corev1.Toleration
+	Threadiness      int
+	NodeName         string
+	JobClusterRole   string
+	DefaultJobImage  string
+	JobTolerations   []corev1.Toleration
+	EnforcePodLimits bool
 }
 
 func (opts Options) Validate() error {

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -82,6 +82,7 @@ func Register(ctx context.Context, systemNamespace, controllerName string, cfg c
 	if opts.DefaultJobImage != "" {
 		chart.DefaultJobImage = opts.DefaultJobImage
 	}
+	chart.EnforcePodLimits = opts.EnforcePodLimits
 	chart.JobTolerations = opts.JobTolerations
 
 	chart.Register(ctx,
@@ -109,6 +110,7 @@ func Register(ctx context.Context, systemNamespace, controllerName string, cfg c
 	logger.Info("Starting helm controller", "threads", opts.Threadiness)
 	logger.Info("Using cluster role for jobs managing helm charts", "jobClusterRole", opts.JobClusterRole)
 	logger.Info("Using default image for jobs managing helm charts", "defaultJobImage", chart.DefaultJobImage)
+	logger.Info("Enforcing resource limits for jobs managing helm charts", "enforcePodLimits", chart.EnforcePodLimits)
 	logger.Info("Using tolerations for jobs managing helm charts", "jobTolerationsCount", len(chart.JobTolerations))
 
 	if len(systemNamespace) == 0 {


### PR DESCRIPTION
Allows the user to disable the recently added resource limits. Addresses feedback with https://github.com/k3s-io/helm-controller/pull/301

https://github.com/k3s-io/helm-controller/issues/324

Signed-off-by: Derek Nola <derek.nola@suse.com>