### PR TITLE
Reduce default helm install job resources (remove 32 CPU / 32G limits)

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -37,8 +37,8 @@ func New() *cli.App {
 			},
 			&cli.StringFlag{
 				Name:        "job-resources",
-				Value:       `{"requests": {"cpu": "0.1", "memory": "10M"}, "limits": {"cpu": "32", "memory": "32G"}}`,
-				Usage:       "JSON spec of resource limits and requests to apply to containers for all jobs managing helm charts",
+				Value:       `{"requests": {"cpu": "0.1", "memory": "10M"}}`,
+				Usage:       "JSON spec of resource requests/limits to apply to containers for all jobs managing helm charts",
 				EnvVars:     []string{"JOB_RESOURCES"},
 				Destination: &cliconfig.JobResources,
 			},


### PR DESCRIPTION
## Summary
This removes the high default limits from `--job-resources` in helm-controller.

Current default includes:
- limits.cpu: 32
- limits.memory: 32G

That default propagates to generated `helm-install-*` Jobs (for example Traefik install jobs in K3s), causing misleading capacity/monitoring signals.

## Change
- Keep default requests:
  - cpu: 0.1
  - memory: 10M
- Remove default limits from the flag default JSON.

## Why
- Avoid surprising 32-core/32G defaults on short-lived installer jobs.
- Keep behavior tunable for operators via `JOB_RESOURCES`.

## Validation
- `go test ./...`

## Related
- k3s issue: https://github.com/k3s-io/k3s/issues/14397
