### PR TITLE
Do not resume job that we are waiting to delete and recreate

### DIFF
--- a/pkg/controllers/chart/chart.go
+++ b/pkg/controllers/chart/chart.go
@@ -52,9 +52,10 @@ const (
 
 	KeyConfigHash = "helmcharts.helm.cattle.io/configHash"
 
-	AnnotationChartURL  = "helm.cattle.io/chart-url"
-	AnnotationManagedBy = "helmcharts.cattle.io/managed-by"
-	AnnotationUnmanaged = "helmcharts.helm.cattle.io/unmanaged"
+	AnnotationChartURL    = "helm.cattle.io/chart-url"
+	AnnotationManagedBy   = "helmcharts.cattle.io/managed-by"
+	AnnotationUnmanaged   = "helmcharts.helm.cattle.io/unmanaged"
+	AnnotationReplaceWait = "helmcharts.helm.cattle.io/replace-wait"
 
 	LabelChartName          = "helmcharts.helm.cattle.io/chart"
 	LabelNodeRolePrefix     = "node-role.kubernetes.io/"
@@ -63,6 +64,12 @@ const (
 
 	chartBySecretIndex       = "helmcharts.helm.cattle.io/chart-by-secret"
 	chartConfigBySecretIndex = "helmcharts.helm.cattle.io/chartconfig-by-secret"
+
+	// DO NOT USE THIS
+	// These are only to be used by the test framework, where we need to create
+	// jobs that the core Kubernetes job controller will not act on.
+	AnnotationJobManager = "helmcharts.helm.cattle.io/job-manager"
+	DefaultJobManager    = "kubernetes.io/job-controller"
 )
 
 var (
@@ -197,6 +204,14 @@ func (c *Controller) reconcileJob(_, newObj runtime.Object) (bool, error) {
 	oldJob, err := c.jobCache.Get(newJob.Namespace, newJob.Name)
 	if err != nil {
 		return false, err
+	}
+	// Add an annotation to the job to prevent jobReady from resuming a job that
+	// we are waiting to delete.
+	if _, ok := oldJob.Annotations[AnnotationReplaceWait]; !ok {
+		b := fmt.Appendf(nil, `{"metadata":{"annotations":{%q:"true"}}}`, AnnotationReplaceWait)
+		if _, err := c.jobs.Patch(oldJob.Namespace, oldJob.Name, types.StrategicMergePatchType, b); err != nil {
+			return false, err
+		}
 	}
 	// To avoid racing, we want to avoid creating and deleting jobs faster than
 	// the controller can keep up. The addition of at least one condition
@@ -746,16 +761,16 @@ func (c *Controller) jobFailed(chart *v1.HelmChart) bool {
 	return false
 }
 
-// jobReady returns true if the job is suspended, has never been started, and
-// the Job controller has added a True Suspended condition to the job for the
-// given chart. The addition of this condition indicates that the controller
-// has observed and synced the job at least once.
+// jobReady returns true if the has never been started, is not waiting to be
+// replaced, is suspended, and the Job controller has added a True Suspended
+// condition to the job for the given chart. The addition of this condition
+// indicates that the controller has observed and synced the job at least once.
 // We create jobs suspended, and look for generation == 1 to indicate that the
 // job has not potentially previously run; we cannot look at status.startTime as
 // this is cleared when the job is suspended.
 func (c *Controller) jobReady(chart *v1.HelmChart) bool {
 	job, _ := c.jobCache.Get(chart.Namespace, jobName(chart))
-	if job != nil && job.Generation == 1 && job.Spec.Suspend != nil && *job.Spec.Suspend {
+	if job != nil && job.Generation == 1 && job.Annotations[AnnotationReplaceWait] == "" && job.Spec.Suspend != nil && *job.Spec.Suspend {
 		for _, condition := range job.Status.Conditions {
 			if condition.Type == batch.JobSuspended {
 				return condition.Status == corev1.ConditionTrue
@@ -978,6 +993,10 @@ func job(chart *v1.HelmChart, apiServerPort string) (*batch.Job, *corev1.Secret,
 				},
 			},
 		},
+	}
+
+	if jobManager := chart.Annotations[AnnotationJobManager]; jobManager != "" && jobManager != DefaultJobManager {
+		job.Spec.ManagedBy = ptr.To(jobManager)
 	}
 
 	if chart.Spec.Timeout != nil {

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -276,6 +276,7 @@ func (f *Framework) UpdateHelmChart(chart *v1.HelmChart, namespace string) (upda
 			return err
 		}
 		updated.Spec = chart.Spec
+		updated.Annotations = chart.Annotations
 		_, err = hcs.HelmCharts(namespace).Update(context.TODO(), updated, metav1.UpdateOptions{})
 		return err
 	}); err != nil {

--- a/test/suite/helm_test.go
+++ b/test/suite/helm_test.go
@@ -11,6 +11,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 
 	v1 "github.com/k3s-io/helm-controller/pkg/apis/helm.cattle.io/v1"
+	chartcontroller "github.com/k3s-io/helm-controller/pkg/controllers/chart"
 	"github.com/k3s-io/helm-controller/test/framework"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -1553,6 +1554,98 @@ var _ = Describe("HelmChart Controller Tests", Ordered, func() {
 			framework.ClientSet.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Delete(ctx, policyName, metav1.DeleteOptions{})
 			framework.ClientSet.AdmissionregistrationV1().ValidatingAdmissionPolicies().Delete(ctx, policyName, metav1.DeleteOptions{})
 
+			err = framework.DeleteHelmChart(chart.Name, chart.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(getHelmChartIgnoreNotFound, 120*time.Second, 5*time.Second).WithArguments(chart.Name, chart.Namespace).Should(BeNil())
+			Eventually(framework.ListSecretReleases, 120*time.Second, 5*time.Second).WithArguments(chart).Should(HaveLen(0))
+		})
+	})
+
+	Context("When config changes before the job is synced", func() {
+		var (
+			err   error
+			chart *v1.HelmChart
+		)
+		BeforeAll(func(ctx SpecContext) {
+			chart = framework.NewHelmChart("traefik-example",
+				"stable/traefik",
+				"1.86.1",
+				"v3",
+				"",
+				"metrics:\n  prometheus:\n    enabled: true\nkubernetes:\n  ingressEndpoint:\n    useDefaultPublishedService: true\nimage: docker.io/rancher/library-traefik\n",
+				map[string]intstr.IntOrString{
+					"rbac.enabled": {
+						Type:   intstr.String,
+						StrVal: "true",
+					},
+					"ssl.enabled": {
+						Type:   intstr.String,
+						StrVal: "true",
+					},
+				})
+			// use custom job manager so that the job doesn't get handled by core kubernetes job controller
+			chart.Annotations = map[string]string{chartcontroller.AnnotationJobManager: "helmcharts.helm.cattle.io/test-suite"}
+			chart, err = framework.CreateHelmChart(chart, framework.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Should create the job suspended", func() {
+			Eventually(getJobIgnoreNotFound, 30*time.Second, 5*time.Second).WithArguments(chart.Namespace, chart.Name).Should(HaveField("Spec.Suspend", HaveValue(BeTrue())))
+		})
+
+		Specify("HelmChartConfig is created", func() {
+			chartConfig := framework.NewHelmChartConfig(chart.Name, "", "metrics:\n  prometheus:\n    enabled: true\nkubernetes:\n  ingressEndpoint:\n    useDefaultPublishedService: true\nimage: docker.io/rancher/library-traefik\n")
+			_, err = framework.CreateHelmChartConfig(chartConfig, framework.Namespace)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Specify("Suspended condition and finalizer are added to the job", func(ctx SpecContext) {
+			Eventually(func(g Gomega) {
+				jobName := "helm-install-" + chart.Name
+				job, err := framework.ClientSet.BatchV1().Jobs(chart.Namespace).Get(context.TODO(), jobName, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				job.Finalizers = []string{"helmcharts.helm.cattle.io/test-suite"}
+				job, err = framework.ClientSet.BatchV1().Jobs(job.Namespace).Update(ctx, job, metav1.UpdateOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				now := metav1.Now()
+				job.Status.Conditions = []batchv1.JobCondition{{
+					Type:               batchv1.JobSuspended,
+					Status:             corev1.ConditionTrue,
+					Reason:             "JobSuspended",
+					Message:            "Job suspended",
+					LastProbeTime:      now,
+					LastTransitionTime: now,
+				}}
+				job, err = framework.ClientSet.BatchV1().Jobs(job.Namespace).UpdateStatus(ctx, job, metav1.UpdateOptions{})
+				g.Expect(err).NotTo(HaveOccurred())
+			}, 30*time.Second, 5*time.Second).Should(Succeed())
+		})
+
+		It("Should delete the job without resuming it first", func() {
+			Eventually(getJobIgnoreNotFound, 30*time.Second, 5*time.Second).WithArguments(chart.Namespace, chart.Name).Should(And(
+				HaveField("ObjectMeta.DeletionTimestamp", Not(BeNil())),
+				HaveField("Spec.Suspend", HaveValue(BeTrue())),
+			))
+		})
+
+		Specify("Clear custom job manager and finalizer before delete", func(ctx SpecContext) {
+			jobName := "helm-install-" + chart.Name
+			job, err := framework.ClientSet.BatchV1().Jobs(chart.Namespace).Get(context.TODO(), jobName, metav1.GetOptions{})
+
+			Expect(err).NotTo(HaveOccurred())
+			job.Finalizers = []string{}
+			_, err = framework.ClientSet.BatchV1().Jobs(job.Namespace).Update(ctx, job, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			delete(chart.Annotations, chartcontroller.AnnotationJobManager)
+			chart, err = framework.UpdateHelmChart(chart, chart.Namespace)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterAll(func(ctx SpecContext) {
 			err = framework.DeleteHelmChart(chart.Name, chart.Namespace)
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
If a change is made that would trigger a recreate of the job while the job is waiting to be observed by the job controller, the chart controller may resume the job and then delete and recreate it in quick succession.

The job is eligible for deletion as soon as conditions are present and there are no active or terminating pods - all of which are satisfied at the same time as the job is eligible to be resumed. This quick resume-and-recreate will trigger the same bug in the job controller that we have been trying to avoid.

Work around this by adding an annotation to the job when we are waiting to replace it, and check for this annotation and do not resume the job if it is present.

Adds another test that uses a custom job manager and finalizer so that the test can control the conditions and deletion of the job.

#### Linked issues:
* SURE-11942
